### PR TITLE
Catch broken fonts (1.10.3-napkin)

### DIFF
--- a/pdf/CHANGELOG.md
+++ b/pdf/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 1.10.3-napkin
+
+- Catch broken fonts (e.g. missing cmap)
+
 ## 3.11.1
 
 - Fixed display problems with textfields [ilaurillard]

--- a/pdf/lib/src/pdf/obj/ttffont.dart
+++ b/pdf/lib/src/pdf/obj/ttffont.dart
@@ -129,7 +129,7 @@ class PdfTtfFont extends PdfFont {
     int charMax;
 
     final ttfWriter = TtfWriter(font);
-    final data = ttfWriter.withChars(unicodeCMap.cmap);
+    final data = ttfWriter.withChars(font, unicodeCMap.cmap);
     file.buf.putBytes(data);
     file.params['/Length1'] = PdfNum(data.length);
 


### PR DESCRIPTION
Example: `≥` with Roboto Regular

![image](https://github.com/user-attachments/assets/df1735a5-025f-437f-a7ba-65fe7806b1b3)
